### PR TITLE
Upgrade to Sinon 2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,8 +25,7 @@ function makeChainable(mock, mockType) {
 }
 
 var oldMock = sinon.mock;
-
-sinon.mock = function mock(object) {
+var newMock = function mock(object) {
   var mockResult = oldMock.apply(this, arguments);
 
   if (object && (object instanceof mongoose.Model || object.schema instanceof mongoose.Schema)) {
@@ -35,3 +34,6 @@ sinon.mock = function mock(object) {
 
   return mockResult;
 };
+
+sinon.mock = newMock;
+sinon.sandbox.mock = newMock;

--- a/package.json
+++ b/package.json
@@ -40,11 +40,10 @@
     "gulp-plumber": "^1.0.0",
     "isparta": "^3.0.3",
     "mongoose": "^4.2.5",
-    "sinon": "1",
-    "sinon-as-promised": "^4.0.0"
+    "sinon": "^2.1.0"
   },
   "peerDependencies": {
-    "sinon": "1"
+    "sinon": "^2.1.0"
   },
   "scripts": {
     "prepublish": "gulp prepublish",

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,6 @@
 var assert = require('assert');
 var sinon = require('sinon');
 var mongoose = require('mongoose');
-require('sinon-as-promised');
 
 require('../lib');
 


### PR DESCRIPTION
Closes #15, This PR adds support to Sinon 2. There has been some changes how sandbox mock works in version 2, so here we need to patch also sandbox.mock -function as well. Also sinon-as-promised is obsolete with Sinon version 2, so it was removed.