### PR TITLE
Fix for sandbox restore()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 coverage
 dist
+## WebStorm
+.idea/

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,4 +36,15 @@ var newMock = function mock(object) {
 };
 
 sinon.mock = newMock;
-sinon.sandbox.mock = newMock;
+
+function sandboxMock(object){
+  var mockResult = oldMock.apply(null, arguments);
+
+  if (object && (object instanceof mongoose.Model || object.schema instanceof mongoose.Schema)) {
+    makeChainable(mockResult);
+  }
+
+  return this.add(mockResult);
+};
+
+sinon.sandbox.mock = sandboxMock;

--- a/test/index.js
+++ b/test/index.js
@@ -107,5 +107,13 @@ describe('sinon-mongoose', function() {
         assert.equal(result, 'RESULT');
       });
     });
+
+    it('Model should be restored properly', function () {
+      var bookMock = sandbox.mock(Book);
+      bookMock.expects("findOne").never();
+      sandbox.restore();
+      var anotherBookMock = sandbox.mock(Book);
+      anotherBookMock.expects("findOne").never();
+    });
   });
 });


### PR DESCRIPTION
Implementation for sandbox mock was not proper (#15, #18). It did not properly restore mongoose model to original state. Here is a test and fix for it