### PR TITLE
Make mock.verify() chainable as well

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,9 @@ function chainMethod(type) {
 
   return function chain(method) {
     var queryMock = sinon.mock(mockType);
+    this.owner.chainedMock = queryMock;
     makeChainable(queryMock, type);
+    makeChainableVerify(queryMock);
     this.returns(queryMock.object);
 
     return queryMock.expects(method);
@@ -19,10 +21,23 @@ function makeChainable(mock, mockType) {
   mock.expects = function(method) {
     mockType = mockType || (method === 'aggregate' ? 'aggregate' : 'query');
     var expectation = expectsMethod.apply(mock, arguments);
+    expectation.owner = mock;
     expectation.chain = chainMethod(mockType).bind(expectation);
     return expectation;
   };
 }
+
+function makeChainableVerify(mockResult){
+  var originalVerify = mockResult.verify;
+  function chainedVerify(){
+    originalVerify.call(mockResult);
+    if(mockResult.chainedMock){
+      mockResult.chainedMock.verify();
+    }
+  }
+  mockResult.verify = chainedVerify;
+}
+
 
 var oldMock = sinon.mock;
 var newMock = function mock(object) {
@@ -30,8 +45,8 @@ var newMock = function mock(object) {
 
   if (object && (object instanceof mongoose.Model || object.schema instanceof mongoose.Schema)) {
     makeChainable(mockResult);
+    makeChainableVerify(mockResult)
   }
-
   return mockResult;
 };
 
@@ -42,6 +57,7 @@ function sandboxMock(object) {
 
   if (object && (object instanceof mongoose.Model || object.schema instanceof mongoose.Schema)) {
     makeChainable(mockResult);
+    makeChainableVerify(mockResult)
   }
 
   return this.add(mockResult);

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@ function makeChainableVerify(mockResult){
   var originalVerify = mockResult.verify;
   function chainedVerify(){
     originalVerify.call(mockResult);
-    if(mockResult.chainedMock){
+    if (mockResult.chainedMock){
       mockResult.chainedMock.verify();
     }
   }
@@ -45,7 +45,7 @@ var newMock = function mock(object) {
 
   if (object && (object instanceof mongoose.Model || object.schema instanceof mongoose.Schema)) {
     makeChainable(mockResult);
-    makeChainableVerify(mockResult)
+    makeChainableVerify(mockResult);
   }
   return mockResult;
 };
@@ -57,7 +57,7 @@ function sandboxMock(object) {
 
   if (object && (object instanceof mongoose.Model || object.schema instanceof mongoose.Schema)) {
     makeChainable(mockResult);
-    makeChainableVerify(mockResult)
+    makeChainableVerify(mockResult);
   }
 
   return this.add(mockResult);

--- a/test/index.js
+++ b/test/index.js
@@ -84,17 +84,17 @@ describe('sinon-mongoose', function() {
 
       bookMock.expects('update')
         .chain('sort')
-        .chain('exec').resolves("RESULT");
+        .chain('exec').resolves('RESULT');
 
-      bookMock.object.update('SOME_ARGUMENTS').exec().then(function(result) {
-        try{
+      bookMock.object.update('SOME_ARGUMENTS').exec().then(function(result) {// eslint-disable-line
+        try {
           bookMock.verify();
           bookMock.restore();
-          done(new Error("should fail to bookMock.verify()"));
-        }catch(err){
+          done(new Error('should fail to bookMock.verify()'));
+        }catch (err){
           bookMock.restore();
-          assert.equal(err.message, "Expected sort([...]) once (never called)");
-          done()
+          assert.equal(err.message, 'Expected sort([...]) once (never called)');
+          done();
         }
       });
     });
@@ -144,20 +144,20 @@ describe('sinon-mongoose', function() {
       bookMock.expects('update')
         .chain('sort').never()
         .chain('limit')
-        .chain('exec').resolves("RESULT");
+        .chain('exec').resolves('RESULT');
 
-      bookMock.object.update('SOME_ARGUMENTS').exec().then(function(result) {
-        try{
+      bookMock.object.update('SOME_ARGUMENTS').exec().then(function(result) {  // eslint-disable-line
+        try {
           bookMock.verify();
           sandbox.restore();
-          done(new Error("should fail to bookMock.verify()"));
-        }catch(err){
+          done(new Error('should fail to bookMock.verify()'));
+        }catch (err){
           sandbox.restore();
-          try{
-            assert.equal(err.message, "Expected limit([...]) once (never called)");
-            done()
-          }catch(err){
-            done(err)
+          try {
+            assert.equal(err.message, 'Expected limit([...]) once (never called)');
+            done();
+          }catch (error){
+            done(error);
           }
         }
       });
@@ -167,22 +167,22 @@ describe('sinon-mongoose', function() {
       var bookMock = sandbox.mock(new Book({ title: 'Rayuela' }));
 
       bookMock.expects('update')
-        .chain('sort').withArgs({field:"asc"})
+        .chain('sort').withArgs({field: 'asc'})
         .chain('limit')
-        .chain('exec').resolves("RESULT");
+        .chain('exec').resolves('RESULT');
 
-      bookMock.object.update('SOME_ARGUMENTS').sort({field:"asc"}).exec().then(function(result) {
-        try{
+      bookMock.object.update('SOME_ARGUMENTS').sort({field: 'asc'}).exec().then(function(result) { // eslint-disable-line
+        try {
           bookMock.verify();
           sandbox.restore();
-          done(new Error("should fail to bookMock.verify()"));
-        }catch(err){
+          done(new Error('should fail to bookMock.verify()'));
+        }catch (err){
           sandbox.restore();
-          try{
-            assert.equal(err.message, "Expected limit([...]) once (never called)");
-            done()
-          }catch(err){
-            done(err)
+          try {
+            assert.equal(err.message, 'Expected limit([...]) once (never called)');
+            done();
+          }catch (error){
+            done(error);
           }
         }
       });


### PR DESCRIPTION
When calling mock.verify() current version only verifies original mock, but doesn't verify properly if chained mocks are called correctly. This PR add support to chained verify calls.

This closes #20. 