### PR TITLE
Removing Travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- prettier-ignore-start -->
-# sinon-mongoose [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![devDependency Status][daviddm-image]][daviddm-url] [![Coverage percentage][coveralls-image]][coveralls-url]
+# sinon-mongoose [![NPM version][npm-image]][npm-url] [![devDependency Status][daviddm-image]][daviddm-url] [![Coverage percentage][coveralls-image]][coveralls-url]
 
 > Extend [Sinon][sinon-url] stubs for [Mongoose][mongoose-url] methods to test chained methods easily
 


### PR DESCRIPTION
Removing the badge since https://travis-ci.org/underscopeio/sinon-mongoose isn't set up and the badge doesn't render.  The badge can be added back in when the build is set up on travis-ci.org