### PR TITLE
Update of the Travis build (NodeJS LTS vers)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js
 node_js:
+  - v12
   - v10
-  - v8
-  - v6
 cache:
   directories:
     - "node_modules"


### PR DESCRIPTION
Remove deprecated versions of NodeJS (v6 and v8)
Add NodeJS 12 to the Travis build