### PR TITLE
add a peer dependency on mongoose to satisfy pnpm's strict dependency…

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -82,5 +82,5 @@ gulp.task(
   })
 )
 
-gulp.task('prepublishOnly', gulp.series('babel'))
+gulp.task('build', gulp.series('babel'))
 gulp.task('default', gulp.series('static', 'test', 'coveralls'))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sinon-mongoose",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Sinon extensions for Mongoose stubs",
   "homepage": "",
   "author": {
@@ -46,6 +46,7 @@
     "sinon": "7.3.1"
   },
   "peerDependencies": {
+    "mongoose": "4 - 5",
     "sinon": "5 - 7"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "sinon": "5 - 7"
   },
   "scripts": {
-    "prepublishOnly": "gulp prepublishOnly",
+    "prepare": "gulp build",
     "test": "gulp"
   },
   "license": "MIT",


### PR DESCRIPTION
This pull request simply adds Mongoose @ versions 4-5 to to the peer dependencies of the sinon-mongoose package.  This satisfies the strictness constraints of dependency managers [pnpm](https://www.kochan.io/nodejs/pnpms-strictness-helps-to-avoid-silly-bugs.html) and [Yarn 2](https://yarnpkg.com/advanced/migration#a-package-is-trying-to-access-another-package-).